### PR TITLE
Remove build-time dependencies and temporary files from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,22 +12,24 @@ LABEL tool_version="${TOOL_VERSION}"
 RUN echo "deb http://cran.univ-paris1.fr/bin/linux/ubuntu xenial/" >> /etc/apt/sources.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
 
-# Update system
-RUN apt-get update
-RUN apt-get -y upgrade
-RUN apt-get install -y --no-install-recommends r-base git make g++ gfortran
-
-# Clone tool repos
-RUN git clone -b v${TOOL_VERSION} https://github.com/workflow4metabolomics/biosigner /files/biosigner
-
-# Install requirements
-RUN R -e "install.packages(c('batch', 'randomForest'), lib='/usr/lib/R/library', dependencies = TRUE, repos='https://cran.rstudio.com')"
-RUN R -e "source('http://bioconductor.org/biocLite.R') ; biocLite('biosigner')"
-
-# Clean
-RUN apt-get clean
-RUN apt-get autoremove -y
-RUN rm -rf /var/lib/{apt,dpkg,cache,log}/ /tmp/* /var/tmp/*
+RUN \
+     apt-get update \
+  && apt-get install -y --no-install-recommends \
+            g++ \
+            gfortran \
+            git \
+            make \
+            r-base \
+   && echo "Cloning biosigner repository" \
+   && git clone --depth 1 --single-branch --branch v${TOOL_VERSION} https://github.com/workflow4metabolomics/biosigner /files/biosigner \
+   && echo "Installing R packages" \
+   && R -e "install.packages(c('batch', 'randomForest'), lib='/usr/lib/R/library', dependencies = TRUE, repos='https://cran.rstudio.com')" \
+   && R -e "source('http://bioconductor.org/biocLite.R') ; biocLite('biosigner')" \
+   && echo "Cleaning..." \
+   && apt-get purge -y g++ gfortran git make \
+   && apt-get autoremove --purge -y \
+   && apt-get clean \
+   && rm -rf /var/lib/{apt,dpkg,cache,log}/ /tmp/* /var/tmp/*
 
 # Make tool accessible through PATH
 ENV PATH=$PATH:/files/biosigner


### PR DESCRIPTION
Though too late for the Cerebellin release, this PR reduces the final image size by about 220 MB by avoiding committing build-time dependencies and temporary files.

*Testing*
I have only minimally tested this PR.  Running (without arguments) doesn't generate any dependency-related exceptions.
